### PR TITLE
fix:bulletの向きを調整及びそれに伴ったプレイヤーの向き更新ロジックの変更

### DIFF
--- a/Assets/Scripts/Player/Ken_Skill.cs
+++ b/Assets/Scripts/Player/Ken_Skill.cs
@@ -15,22 +15,20 @@ public class Ken_Skill : CharacterSkill
 
         if (bulletPrefab != null && bulletSpawnPoint != null)
         {
-            // ■ Y軸回転を想定した弾の発射 ■
+            // 弾を、弾の発射地点(bulletSpawnPoint)の「位置」と「向き」に合わせて生成
+            GameObject bullet = Instantiate(bulletPrefab, bulletSpawnPoint.position, Quaternion.identity);
 
-            // 弾を、弾の発射地点(bulletSpawnPoint)の「位置」と「向き」に合わせて生成します。
-            GameObject bullet = Instantiate(bulletPrefab, bulletSpawnPoint.position, bulletSpawnPoint.rotation);
-            
             Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
+            if (transform.localScale.x < 0)
+            {
+                Quaternion currentRotation = bullet.transform.rotation;
+                Quaternion NewRotation = Quaternion.Euler(currentRotation.eulerAngles.x, currentRotation.eulerAngles.y, currentRotation.eulerAngles.z +180f);
+                bullet.transform.rotation = NewRotation;
+            }
             if (rb != null)
             {
-                // 弾を発射地点の向き（右方向）に飛ばします。
-                // プレイヤーがY軸で180度回転して左を向いていれば、
-                // 子であるbulletSpawnPointのright（右方向）も自動的に左を向いています。
-                rb.linearVelocity = bulletSpawnPoint.right * bulletSpeed;
-            }
-            else
-            {
-                Debug.LogError("Bullet PrefabにRigidbody2Dがアタッチされていません！");
+                // プレイヤーの向き（localScale.x）に応じて速度を設定
+                rb.linearVelocity = new Vector2(transform.localScale.x * bulletSpeed, 0);
             }
         }
         else

--- a/Assets/Scripts/Player/Uruha_Skill.cs
+++ b/Assets/Scripts/Player/Uruha_Skill.cs
@@ -3,27 +3,36 @@ using System.Collections;
 
 public class Uruha_Skill : CharacterSkill
 {
-    public float SkillRecastTime = 10.0f;
+    public float SkillRecastTime = 15.0f;
 
-    // 生成する弾のプレハブ
     public GameObject bulletPrefab;
-    // 弾を生成する場所
     public Transform bulletSpawnPoint;
+    public float bulletSpeed = 10f;
 
     public override void PerformSkill()
     {
         Debug.Log("uruha skill");
 
-        // プレハブと生成場所が設定されているか確認
         if (bulletPrefab != null && bulletSpawnPoint != null)
         {
-            // 1. Instantiateでプレハブをシーン上に生成し、そのインスタンスを newBullet 変数に格納
-            GameObject newBullet = Instantiate(bulletPrefab, bulletSpawnPoint.position, bulletSpawnPoint.rotation);
-            
-            // 2. 生成した弾からBulletコンポーネントを取得
-            Bullet bulletComponent = newBullet.GetComponent<Bullet>();
+            // 弾を、弾の発射地点(bulletSpawnPoint)の「位置」と「向き」に合わせて生成
+            GameObject bullet = Instantiate(bulletPrefab, bulletSpawnPoint.position, Quaternion.identity);
 
-            // 3. 取得したコンポーネントの isPenetrating フラグを true に設定
+            Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
+            if (transform.localScale.x < 0)
+            {
+                Quaternion currentRotation = bullet.transform.rotation;
+                Quaternion NewRotation = Quaternion.Euler(currentRotation.eulerAngles.x, currentRotation.eulerAngles.y, currentRotation.eulerAngles.z + 180f);
+                bullet.transform.rotation = NewRotation;
+            }
+            if (rb != null)
+            {
+                // プレイヤーの向き（localScale.x）に応じて速度を設定
+                rb.linearVelocity = new Vector2(transform.localScale.x * bulletSpeed, 0);
+            }
+            // 生成した弾からBulletコンポーネント取得
+            Bullet bulletComponent = bullet.GetComponent<Bullet>();
+            // 取得したコンポーネントの isPenetrating フラグを true に設定
             if (bulletComponent != null)
             {
                 // この弾を「貫通弾」に設定する

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -126,11 +126,11 @@ public class PlayerController : MonoBehaviour
         {
             if (moveInput < 0)
             {
-                transform.eulerAngles = new Vector3(0, 180, 0);
+                 transform.localScale = new Vector3(-Mathf.Abs(transform.localScale.x), transform.localScale.y, transform.localScale.z);
             }
             else if (moveInput > 0)
             {
-                transform.eulerAngles = new Vector3(0, 0, 0);
+                transform.localScale = new Vector3(Mathf.Abs(transform.localScale.x), transform.localScale.y, transform.localScale.z);
             }
         }
     }


### PR DESCRIPTION
Bulletの射出を後ろ向いてる時に後ろに出るようにPlayerControllerの向き変更ロジックを改変してます
プレイヤー向きを参照して何かを実装しているスクリプトに何かしら影響を及ぼしてる可能性があります
・月ノ美兎及び一ノ瀬うるはの後ろ向いた際の通常攻撃の挙動が少しおかしいことは確認済み
今後、何か見つかればバグ修正期間に治します